### PR TITLE
Fix ATCS and LATISS import statements.

### DIFF
--- a/python/lsst/ts/externalscripts/auxtel/latiss_acquire_and_take_sequence.py
+++ b/python/lsst/ts/externalscripts/auxtel/latiss_acquire_and_take_sequence.py
@@ -21,19 +21,21 @@
 __all__ = ["LatissAcquireAndTakeSequence"]
 
 import yaml
+import warnings
 import asyncio
 import numpy as np
 
 from lsst.ts import salobj
-from lsst.ts.standardscripts.auxtel.attcs import ATTCS
-from lsst.ts.standardscripts.auxtel.latiss import LATISS
+from lsst.ts.observatory.control.auxtel import ATCS, LATISS
 
-# from lsst.ts.idl.enums.Script import ScriptState
+try:
+    from lsst.observing.utils.audio import playSound
+    from lsst.observing.utils.filters import changeFilterAndGrating, getFilterAndGrating
+    from lsst.observing.utils.offsets import findOffsetsAndMove
+    from lsst.observing.constants import boreSight, sweetSpots
+except ImportError:
+    warnings.warn("Cannot import lsst.observing. Script will not work.")
 
-from lsst.observing.utils.audio import playSound
-from lsst.observing.utils.filters import changeFilterAndGrating, getFilterAndGrating
-from lsst.observing.utils.offsets import findOffsetsAndMove
-from lsst.observing.constants import boreSight, sweetSpots
 
 import lsst.daf.persistence as dafPersist
 
@@ -69,7 +71,7 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
             index=index, descr="Perform target acquisition for LATISS instrument."
         )
 
-        self.attcs = ATTCS(self.domain)
+        self.attcs = ATCS(self.domain)
         self.latiss = LATISS(self.domain)
 
         # Suppress verbosity

--- a/python/lsst/ts/externalscripts/auxtel/latiss_acquire_target.py
+++ b/python/lsst/ts/externalscripts/auxtel/latiss_acquire_target.py
@@ -21,15 +21,19 @@
 __all__ = ["LatissAcquireTarget"]
 
 import yaml
+import warnings
 
 from lsst.ts import salobj
-from lsst.ts.standardscripts.auxtel.attcs import ATTCS
-from lsst.ts.standardscripts.auxtel.latiss import LATISS
+from lsst.ts.observatory.control.auxtel import ATCS
+from lsst.ts.observatory.control.auxtel import LATISS
 
 import lsst.daf.persistence as dafPersist
 
 # Import Robert's CalibrationStarVisit method
-import lsst.observing.commands.calibrationStarVisit as calibrationStarVisit
+try:
+    import lsst.observing.commands.calibrationStarVisit as calibrationStarVisit
+except ImportError:
+    warnings.warn("Cannot import lsst.observing. Script will not work.")
 
 
 class LatissAcquireTarget(salobj.BaseScript):
@@ -67,7 +71,7 @@ class LatissAcquireTarget(salobj.BaseScript):
         self.attcs = None
         self.latiss = None
         if remotes:
-            self.attcs = ATTCS(self.domain)
+            self.attcs = ATCS(self.domain)
             self.latiss = LATISS(self.domain)
 
         self.short_timeout = 5.0

--- a/python/lsst/ts/externalscripts/auxtel/latiss_take_sequence.py
+++ b/python/lsst/ts/externalscripts/auxtel/latiss_take_sequence.py
@@ -21,15 +21,19 @@
 __all__ = ["LatissTakeSequence"]
 
 import yaml
+import warnings
 
 from lsst.ts import salobj
-from lsst.ts.standardscripts.auxtel.attcs import ATTCS
-from lsst.ts.standardscripts.auxtel.latiss import LATISS
+from lsst.ts.observatory.control.auxtel import ATCS
+from lsst.ts.observatory.control.auxtel import LATISS
 
 import lsst.daf.persistence as dafPersist
 
 # Import Robert's CalibrationStarVisit method
-import lsst.observing.commands.calibrationStarVisit as calibrationStarVisit
+try:
+    import lsst.observing.commands.calibrationStarVisit as calibrationStarVisit
+except ImportError:
+    warnings.warn("Cannot import lsst.observing. Script will not work.")
 
 
 class LatissTakeSequence(salobj.BaseScript):
@@ -63,7 +67,7 @@ class LatissTakeSequence(salobj.BaseScript):
         self.attcs = None
         self.latiss = None
         if remotes:
-            self.attcs = ATTCS(self.domain)
+            self.attcs = ATCS(self.domain)
             self.latiss = LATISS(self.domain)
 
         self.short_timeout = 5.0

--- a/ups/ts_externalscripts.table
+++ b/ups/ts_externalscripts.table
@@ -1,5 +1,4 @@
 setupRequired(sconsUtils)
-setupRequired(ts_sal)
 setupRequired(ts_salobj)
 setupRequired(ts_observatory_control)
 


### PR DESCRIPTION
Remove ts_sal from eups requirements table.
Ignore (with a warning) error importing observing package.