### PR TITLE
updated tests in cwfs to use the ready_to_take_image functionality.

### DIFF
--- a/python/lsst/ts/externalscripts/auxtel/latiss_acquire_and_take_sequence.py
+++ b/python/lsst/ts/externalscripts/auxtel/latiss_acquire_and_take_sequence.py
@@ -85,7 +85,11 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
         )
 
         self.atcs = ATCS(self.domain, log=self.log)
-        self.latiss = LATISS(self.domain, log=self.log)
+        self.latiss = LATISS(
+            self.domain,
+            log=self.log,
+            tcs_ready_to_take_data=self.atcs.ready_to_take_data,
+        )
         # instantiate the quick measurement class
         try:
             qm_config = QuickFrameMeasurementTask.ConfigClass()
@@ -209,6 +213,12 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
                 type: boolean
                 default: False
 
+              do_blind_offset:
+                description: Perform blind offset during the slew. Useful to reduce iterations
+                    so long as pointing model is accurate.
+                type: boolean
+                default: True
+
             additionalProperties: false
             required: [object_name]
         """
@@ -234,6 +244,8 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
         self.do_take_sequence = config.do_take_sequence
         # Do pointing file generation?
         self.do_pointing_model = config.do_pointing_model
+        # Perform blind offsetting?
+        self.do_blind_offset = config.do_blind_offset
 
         # Object name
         assert config.object_name is not None
@@ -320,43 +332,37 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
         else:
             target_position = latiss_constants.sweet_spots[self.acq_grating]
 
-        # get filter/disperser currently in the beam
-        (
-            current_filter,
-            current_grating,
-            current_stage_pos,
-        ) = await self.latiss.get_setup()
+        # Find offsets to desired detector position, calculate blind offset
+        # and send as part of the slew command
+        self.log.info(f"Performing Blind offset set to {self.do_blind_offset}")
+        if self.do_blind_offset:
+            current_position = latiss_constants.boresight
 
-        # Is the atspectrograph Correction in the ATAOS running?
-        corr = await self.atcs.rem.ataos.evt_correctionEnabled.aget(
-            timeout=self.cmd_timeout
-        )
+            dx_arcsec, dy_arcsec = calculate_xy_offsets(
+                current_position, target_position
+            )
+            self.log.debug(
+                f"After slew, the target should be at the boresight [{current_position}] whereas the "
+                f"target position is {target_position}. Blindly offsetting"
+                f" [{dx_arcsec:0.1f}, {dy_arcsec:0.1f}] arcsec to this position."
+            )
+        else:
+            dx_arcsec, dy_arcsec = 0.0, 0.0
 
         # Setup instrument and telescope
-        # Following code requires persistent offsets to be functional, but
-        # that's not yet the case therefore this will result in a race
-        # condition where the pointing offsets might be wiped out.
-        # await asyncio.gather(
-        #     self.atcs.slew_object(name=self.object_name,
-        #     rot=rot_type=RotType.Parallactic, slew_timeout=240)
-        #     self.latiss.setup_instrument(grating=self.acq_grating,
-        #     filter=self.acq_filter),
-        # )
-
-        # Slew and setup in series for now
-        # set rot_type to align to parallactic angle
-        # await self.atcs.slew_object(
-        #     name=self.object_name, rot_type=RotType.Parallactic,
-        #     slew_timeout=240
-        # )
-
-        # FIXME: Impelemented due to rotator issues - revert in DM-29217
-        await self.atcs.slew_object(
-            name=self.object_name,
-            rot_type=RotType.PhysicalSky,
-            rot=-105,
-            slew_timeout=240,
+        # The following code sets up the instrument and slews the telescope
+        # simultaneously.
+        tmp, data = await asyncio.gather(
+            self.atcs.slew_object(
+                name=self.object_name,
+                rot_type=RotType.Parallactic,
+                slew_timeout=240,
+                offset_x=dx_arcsec,
+                offset_y=dy_arcsec,
+            ),
+            self.latiss.setup_atspec(grating=self.acq_grating, filter=self.acq_filter),
         )
+
         # Apply manual focus offset if required
         if self.manual_focus_offset != 0.0 and not self.manual_focus_offset_applied:
             self.log.debug(
@@ -364,73 +370,6 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
             )
             await self.atcs.rem.ataos.cmd_offset.set_start(z=self.manual_focus_offset)
             self.manual_focus_offset_applied = True
-
-        # Check if a new instrument configuration is required
-        _new_instrument_required = (self.acq_filter != current_filter) or (
-            self.acq_grating != current_grating
-        )
-        self.log.debug(f"Instrument setup required: {_new_instrument_required}")
-        if _new_instrument_required:
-            self.log.debug(
-                f"Must load new filter {self.acq_filter} or grating {self.acq_grating}"
-            )
-
-            if corr.atspectrograph:
-                # If so, then flush correction events for confirmation of
-                # corrections
-                self.atcs.rem.ataos.evt_atspectrographCorrectionStarted.flush()
-                self.atcs.rem.ataos.evt_atspectrographCorrectionCompleted.flush()
-
-        # Once persistent offsets are working this line should be removed
-        # and the slew+setup should be performed asynchronously as seen
-        # in the asyncio.gather statement above.
-
-        # FIXME - need to use setup_atspec for unit tests to work
-        # data = await self.latiss.setup_instrument(
-        #              grating=self.acq_grating, filter=self.acq_filter)
-
-        # Setup the instrument with the new configuration
-        # data = await self.latiss.setup_instrument(filter=filt,
-        #              grating=grating)
-        data = await self.latiss.setup_atspec(
-            filter=self.acq_filter, grating=self.acq_grating
-        )
-
-        # If ATAOS is running wait for adjustments to complete before
-        # moving on.
-        if corr.atspectrograph and _new_instrument_required:
-
-            self.log.debug(
-                "Instrument setup in acquisition now waiting for "
-                f"2*len{data} ATAOS events saying correction started/finished"
-            )
-
-            # loop to grab all events
-            for j in range(len(data)):
-                # flush=false removes the event when grabbed
-                _evt1 = (
-                    await self.atcs.rem.ataos.evt_atspectrographCorrectionStarted.next(
-                        flush=False, timeout=self.cmd_timeout
-                    )
-                )
-                self.log.debug(
-                    f"Event #{j} - evt_atspectrographCorrectionStarted is: {_evt1}"
-                )
-            for j in range(len(data)):
-                _evt2 = await self.atcs.rem.ataos.evt_atspectrographCorrectionCompleted.next(
-                    flush=False, timeout=self.cmd_timeout
-                )
-                self.log.debug(
-                    f"Event #{j} - evt_atspectrographCorrectionCompleted is: {_evt2}"
-                )
-
-            self.log.debug("ATAOS atspectrographCorrectionXXXX events arrived")
-
-            self.log.info(
-                "sleeping for 2s after acquisition due to ATAOS issue "
-                "where corrections might take an extra cycle"
-            )
-            await asyncio.sleep(2)
 
         self.log.info(
             "Beginning Acquisition Iterative Loop, with a maximum amount of "
@@ -444,12 +383,15 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
                 f"\nStarting iteration number {iter_num + 1}, with a "
                 f"maximum of {self.max_acq_iter}"
             )
-            tmp, data_id = await asyncio.gather(
-                self.latiss.take_object(exptime=self.acq_exposure_time, n=1),
-                self.get_next_image_data_id(
-                    timeout=self.acq_exposure_time + STD_TIMEOUT
-                ),
+
+            # Was not catching event from OODS in time without timing out
+            self.latiss.rem.atarchiver.evt_imageInOODS.flush()
+            tmp = await self.latiss.take_object(exptime=self.acq_exposure_time, n=1)
+            data_id = await self.get_next_image_data_id(
+                timeout=self.acq_exposure_time + STD_TIMEOUT, flush=False
             )
+            self.log.debug(f"Take Object returned {tmp}")
+            self.log.debug("Now waiting for image to land in OODS")
 
             exp = await get_image(
                 data_id,
@@ -482,7 +424,7 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
                 result.brightestObjCentroid[0], result.brightestObjCentroid[1]
             )
 
-            # Find offsets
+            # Find offsets to desired position
             self.log.debug(
                 f"Current brightest target position is {current_position} whereas the "
                 f"target position is {target_position}"
@@ -517,10 +459,8 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
             # Offset telescope, using persistent offsets
             self.log.info("Applying x/y offset to telescope pointing.")
 
-            # Use persistent = False otherwise when we go to use
-            # the hologram it offsets to the bottom of the field
-            # FIXME: need to decide how we want to handle persistent offsets
-            # DM-29217
+            # Use persistent = False otherwise when we switch gratings
+            # it may keep an offset we no longer want
             await self.atcs.offset_xy(
                 dx_arcsec, dy_arcsec, relative=True, persistent=False
             )
@@ -595,73 +535,10 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
             # Focus and pointing offsets will be made automatically
             # by the TCS upon filter/grating changes
 
-            # get current filter/disperser
-            (
-                current_filter,
-                current_grating,
-                current_stage_pos,
-            ) = await self.latiss.get_setup()
-
-            # Check if a new configuration is required
-            _new_instrument_required = (filt != current_filter) or (
-                grating != current_grating
-            )
-
-            if _new_instrument_required:
-                self.log.debug(f"Must load new filter {filt} or grating {grating}")
-
-                # Is the atspectrograph Correction in the ATAOS running?
-                corr = await self.atcs.rem.ataos.evt_correctionEnabled.aget(
-                    timeout=self.cmd_timeout
-                )
-                if corr.atspectrograph:
-                    # If so, then flush correction events for confirmation
-                    # of corrections
-                    self.atcs.rem.ataos.evt_atspectrographCorrectionStarted.flush()
-                    self.atcs.rem.ataos.evt_atspectrographCorrectionCompleted.flush()
-
-                # Setup the instrument with the new configuration
-                # data = await self.latiss.setup_instrument(filter=filt,
-                #               grating=grating)
-                # FIXME - need to use setup_atspec for unit tests to work
-                data = await self.latiss.setup_atspec(filter=filt, grating=grating)
-                # If ATAOS is running wait for adjustments to complete before
-                # moving on.
-                if corr.atspectrograph:
-                    self.log.debug(
-                        "Instrument setup in take_sequence now waiting for "
-                        f"2*len{data} ATAOS events saying correction started/finished"
-                    )
-
-                    # loop to grab all events
-                    for j in range(len(data)):
-                        # flush=false removes the event when grabbed
-                        _evt1 = await self.atcs.rem.ataos.evt_atspectrographCorrectionStarted.next(
-                            flush=False, timeout=self.cmd_timeout
-                        )
-                        self.log.debug(
-                            f"Event #{j} - evt_atspectrographCorrectionStarted is: {_evt1}"
-                        )
-                    for j in range(len(data)):
-                        _evt2 = await self.atcs.rem.ataos.evt_atspectrographCorrectionCompleted.next(
-                            flush=False, timeout=self.cmd_timeout
-                        )
-                        self.log.debug(
-                            f"Event #{j} - evt_atspectrographCorrectionCompleted is: {_evt2}"
-                        )
-
-                    self.log.debug(
-                        "ATAOS atspectrographCorrectionStarted and Completed events arrived"
-                    )
-
-                    self.log.info(
-                        "sleeping for 2s after acquisition due to ATAOS issue "
-                        "where corrections might take an extra cycle"
-                    )
-                    await asyncio.sleep(2)
-
             # Take an image
-            await self.latiss.take_object(exptime=expTime, n=1, group_id=group_id)
+            await self.latiss.take_object(
+                exptime=expTime, n=1, group_id=group_id, filter=filt, grating=grating
+            )
 
             self.log.info(
                 f"Completed exposure {i + 1} of {nexp}. Exptime = {expTime:6.1f}s,"

--- a/python/lsst/ts/externalscripts/auxtel/latiss_cwfs_align.py
+++ b/python/lsst/ts/externalscripts/auxtel/latiss_cwfs_align.py
@@ -98,8 +98,12 @@ class LatissCWFSAlign(salobj.BaseScript):
         self.atcs = None
         self.latiss = None
         if remotes:
-            self.atcs = ATCS(self.domain)
-            self.latiss = LATISS(self.domain)
+            self.atcs = ATCS(self.domain, log=self.log)
+            self.latiss = LATISS(
+                self.domain,
+                log=self.log,
+                tcs_ready_to_take_data=self.atcs.ready_to_take_data,
+            )
 
         # instantiate the quick measurement class
         try:
@@ -410,8 +414,7 @@ Pixel_size (m)			{}
         dr = np.sqrt(dy ** 2 + dx ** 2)
         if dr > 100.0:
             raise RuntimeError(
-                "Intra and Extra source finding algorithm "
-                "found different sources."
+                "Intra and Extra source finding algorithm " "found different sources."
             )
 
         # Create stamps for CWFS algorithm. Bin (if desired).
@@ -719,7 +722,7 @@ Telescope offsets [arcsec]: {(len(tel_offset) * '{:0.1f}, ').format(*tel_offset)
                     f"Hexapod LUT Datapoint - {current_target.targetName} - "
                     f"reported hexapod position is, {hexapod_position.reportedPosition}."
                 )
-                self.log.debug("Taking in focus acquisition image.")
+                self.log.debug("Taking in focus image after applying final results.")
                 await self.latiss.take_object(self.acq_exposure_time)
                 await self.atcs.add_point_data()
 

--- a/tests/auxtel/test_latiss_cwfs_align.py
+++ b/tests/auxtel/test_latiss_cwfs_align.py
@@ -30,6 +30,7 @@ import os
 try:
     # TODO: (DM-24904) Remove this try/except clause when WEP is adopted
     from lsst import cwfs
+
     CWFS_AVAILABLE = True
 except ImportError:
     CWFS_AVAILABLE = False
@@ -101,6 +102,7 @@ class TestLatissCWFSAlign(
         self.atcamera.cmd_takeImages.callback = unittest.mock.AsyncMock(
             wraps=self.cmd_take_images_callback
         )
+        self.script.latiss.ready_to_take_data = salobj.make_done_future
         # mock latiss instrument setup
         self.script.latiss.setup_atspec = unittest.mock.AsyncMock()
 
@@ -172,8 +174,7 @@ class TestLatissCWFSAlign(
 
     @unittest.skipIf(
         CWFS_AVAILABLE is False,
-        f"CWFS package availibility is {CWFS_AVAILABLE}."
-        f"Skipping test_configure.",
+        f"CWFS package availibility is {CWFS_AVAILABLE}. Skipping test_configure.",
     )
     async def test_configure(self):
         async with self.make_script():


### PR DESCRIPTION
Added blind offset to the script in the slew command.
Removed asynchonous image taking and atarchiver event listening as it was causing failues.
Added flush before taking image to avoid race condition
Updated unit tests and code to have the ATAOS automatic offsets be handled by the latiss class
Removed rotator restrictions and now it is set to track the parallactic angle