### PR TITLE
DM-34130: Add support for additional image type in observatory control package and document them in a more visible place

### DIFF
--- a/python/lsst/ts/externalscripts/auxtel/build_pointing_model.py
+++ b/python/lsst/ts/externalscripts/auxtel/build_pointing_model.py
@@ -303,7 +303,7 @@ additionalProperties: false
 
         self.latiss.rem.atoods.evt_imageInOODS.flush()
 
-        acquisition_image_ids = await self.latiss.take_engtest(
+        acquisition_image_ids = await self.latiss.take_acq(
             exptime=self.config.exposure_time,
             n=1,
             group_id=self.group_id,
@@ -320,7 +320,7 @@ additionalProperties: false
 
         await self.atcs.offset_xy(x=offset_x, y=offset_y)
 
-        await self.latiss.take_engtest(
+        await self.latiss.take_acq(
             exptime=self.config.exposure_time,
             n=1,
             group_id=self.group_id,

--- a/python/lsst/ts/externalscripts/auxtel/latiss_acquire_and_take_sequence.py
+++ b/python/lsst/ts/externalscripts/auxtel/latiss_acquire_and_take_sequence.py
@@ -507,7 +507,7 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
 
             # Was not catching event from OODS in time without timing out
             self.latiss.rem.atoods.evt_imageInOODS.flush()
-            tmp = await self.latiss.take_object(
+            tmp = await self.latiss.take_acq(
                 exptime=self.acq_exposure_time,
                 n=1,
                 group_id=self.group_id,
@@ -619,7 +619,7 @@ class LatissAcquireAndTakeSequence(salobj.BaseScript):
 
         # Verify with another image that we're on target?
         if self.target_pointing_verification:
-            await self.latiss.take_object(
+            await self.latiss.take_acq(
                 exptime=self.acq_exposure_time,
                 n=1,
                 group_id=self.group_id,

--- a/python/lsst/ts/externalscripts/auxtel/latiss_cwfs_align.py
+++ b/python/lsst/ts/externalscripts/auxtel/latiss_cwfs_align.py
@@ -283,7 +283,7 @@ Pixel_size (m)			{}
 
         await self.hexapod_offset(self.dz)
 
-        intra_image = await self.latiss.take_engtest(
+        intra_image = await self.latiss.take_cwfs(
             exptime=self.exposure_time,
             n=1,
             group_id=self.group_id,
@@ -302,7 +302,7 @@ Pixel_size (m)			{}
 
         self.log.debug("Taking extra-focal image")
 
-        extra_image = await self.latiss.take_engtest(
+        extra_image = await self.latiss.take_cwfs(
             exptime=self.exposure_time,
             n=1,
             group_id=self.group_id,
@@ -877,7 +877,7 @@ Telescope offsets [arcsec]: {(len(tel_offset) * '{:0.1f}, ').format(*tel_offset)
         if self.take_detection_image:
             if checkpoint:
                 await self.checkpoint("Detection image.")
-            await self.latiss.take_engtest(
+            await self.latiss.take_acq(
                 self.acq_exposure_time,
                 group_id=self.group_id,
                 reason="DETECTION_INFOCUS"
@@ -951,7 +951,7 @@ Telescope offsets [arcsec]: {(len(tel_offset) * '{:0.1f}, ').format(*tel_offset)
                     f"reported hexapod position is, {hexapod_position.reportedPosition}."
                 )
                 self.log.debug("Taking in focus image after applying final results.")
-                await self.latiss.take_object(
+                await self.latiss.take_acq(
                     self.acq_exposure_time,
                     group_id=self.group_id,
                     reason="FINAL_INFOCUS"

--- a/tests/auxtel/test_build_pointing_model.py
+++ b/tests/auxtel/test_build_pointing_model.py
@@ -253,7 +253,7 @@ class TestBuildPointingModel(BaseScriptTestCase, unittest.IsolatedAsyncioTestCas
                 unittest.mock.Mock(),
                 "flush",
             )
-            self.script.latiss.take_engtest = unittest.mock.AsyncMock(
+            self.script.latiss.take_acq = unittest.mock.AsyncMock(
                 return_value=self.find_offset_image_id
             )
 
@@ -272,7 +272,7 @@ class TestBuildPointingModel(BaseScriptTestCase, unittest.IsolatedAsyncioTestCas
 
         self.script.latiss.rem.atoods.evt_imageInOODS.flush.assert_called_once()
 
-        take_engtest_calls = [
+        take_acq_calls = [
             unittest.mock.call(
                 exptime=self.script.config.exposure_time,
                 n=1,
@@ -293,7 +293,7 @@ class TestBuildPointingModel(BaseScriptTestCase, unittest.IsolatedAsyncioTestCas
             flush=False, timeout=self.script.image_in_oods_timeout
         )
 
-        self.script.latiss.take_engtest.assert_has_awaits(take_engtest_calls)
+        self.script.latiss.take_acq.assert_has_awaits(take_acq_calls)
 
         self.script.find_offset.assert_awaited_once_with(
             image_id=self.find_offset_image_id[0]


### PR DESCRIPTION
Note that this PR has some updates coming from the AuxTel run branch (DM-34581). I am opening the PR now but I will wait until we get DM-34581 merged than rebase. I just want to get the PR out. 