### PR TITLE
Quick bug fix in random_walk.py

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -9,6 +9,14 @@ Version History
 v0.25.0
 -------
 
+* In ``random_walk.py``:
+    * The ``random_walk_azel_by_time`` function now returns a dataclass
+    * Replace ``.get`` calls with ``.aget`` calls 
+    * Fix/improve docstring in RandomWalkData
+    * Remove unused variable ```data```
+    * Remove/improve log messages in ``random_walk_by_time``
+    * Improve random_walk_azel_by_time docstring to explain the name ``origin``
+
 * Add new script ``latiss_acquire.py`` for AuxTel.
   This script is used to slew to a target and center it at a specific position.
   

--- a/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
+++ b/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
@@ -34,10 +34,9 @@ from lsst.ts.standardscripts.base_track_target import BaseTrackTarget
 @dataclass
 class RandomWalkData:
     """Stores information used during the execution of the RandomWalk
-    script. The most critical data are the `new_az` and `new_el`.
-    The script uses them to calculate an offset relative to the initial
-    position on sky of the previous target.
-    This avoids a "trend" in azimuth.
+    script. The script uses `az` and `el` to calculate an offset relative 
+    to the initial position on sky of the previous target. This avoids a 
+    "trend" in azimuth movement.
 
     Attributes
     ----------
@@ -244,10 +243,6 @@ class RandomWalk(BaseTrackTarget):
         """
         counter = 0
         timer_task = asyncio.create_task(asyncio.sleep(self.config.total_time))
-        self.log.info(
-            f"{'Time':25s}{'Steps':>10s}{'Old Az':>10s}{'New Az':>10s}"
-            f"{'Old El':>10s}{'New El':>10s}{'Offset':>10s}"
-        )
 
         n_points = 10
         current_az = np.median(
@@ -301,17 +296,20 @@ class RandomWalk(BaseTrackTarget):
             new_radec = self.tcs.radec_from_azel(az=new_az, el=new_el)
             sky_offset = current_radec.separation(new_radec).value
 
-            t = Time.now().to_value("isot")
             self.log.info(
-                f"{t:25s}{counter:10d}{current_az:10.2f}{new_az:10.2f}"
-                f"{current_el:10.2f}{new_el:10.2f}{sky_offset:10.2f}"
+                f"{counter=:>10s}"
+                f"{current_az=:>10s}"
+                f"{new_az=:>10s}"
+                f"{old_el=:>10s}"
+                f"{new_el=:>10s}"
+                f"{sky_offset=:10s}"
             )
 
-            # Yield sky offset for testing purposes
-            data = RandomWalkData(
+            # Yield the sky offset for testing purposes and
+            # and the counter to be displayed in the checkpoints
+            yield RandomWalkData(
                 counter=counter, az=new_az, el=new_el, offset=sky_offset
             )
-            yield data
 
             counter += 1
             current_az, current_el = new_az, new_el

--- a/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
+++ b/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
@@ -237,8 +237,8 @@ class RandomWalk(BaseTrackTarget):
             )
 
     async def random_walk_azel_by_time(self):
-        """Generate Az/El coordinates for a a long time so we can slew and
-        track to these targets.
+        """Generate Az/El coordinates using random offsets for a finite 
+        amount of time. 
         """
         counter = 0
         timer_task = asyncio.create_task(asyncio.sleep(self.config.total_time))

--- a/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
+++ b/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
@@ -241,7 +241,6 @@ class RandomWalk(BaseTrackTarget):
         amount of time.
         """
         counter = 0
-        timer_task = asyncio.create_task(asyncio.sleep(self.config.total_time))
 
         n_points = 10
         current_az_list = [
@@ -255,6 +254,8 @@ class RandomWalk(BaseTrackTarget):
             for _ in range(n_points)
         ]
         current_el = np.abs(np.median([el.actualPosition for el in current_el_list]))
+
+        timer_task = asyncio.create_task(asyncio.sleep(self.config.total_time))
 
         while not timer_task.done():
             current_radius = (

--- a/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
+++ b/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
@@ -201,7 +201,7 @@ class RandomWalk(BaseTrackTarget):
         metadata.duration = self.config.total_time
 
     async def run(self):
-        async for i, az, el in self.random_walk_azel_by_time():
+        async for i, az, el, _ in self.random_walk_azel_by_time():
             await self.checkpoint(f"[{i}] Tracking {az=}/{el=}.")
             await self.slew_and_track(az, el, target_name=f"random_walk_{i}")
 

--- a/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
+++ b/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
@@ -252,13 +252,21 @@ class RandomWalk(BaseTrackTarget):
         n_points = 10
         current_az = np.median(
             [
-                self.tcs.rem.mtmount.tel_azimuth.get().actualPosition
+                (
+                    await self.tcs.rem.mtmount.tel_azimuth.aget(
+                        timeout=self.tcs.fast_timeout
+                    )
+                ).actualPosition
                 for i in range(n_points)
             ]
         )
         current_el = np.median(
             [
-                self.tcs.rem.mtmount.tel_elevation.get().actualPosition
+                (
+                    await self.tcs.rem.mtmount.tel_elevation.aget(
+                        timeout=self.tcs.fast_timeout
+                    )
+                ).actualPosition
                 for i in range(n_points)
             ]
         )

--- a/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
+++ b/python/lsst/ts/externalscripts/maintel/tma/random_walk.py
@@ -237,8 +237,8 @@ class RandomWalk(BaseTrackTarget):
             )
 
     async def random_walk_azel_by_time(self):
-        """Generate Az/El coordinates using random offsets for a finite 
-        amount of time. 
+        """Generate Az/El coordinates using random offsets for a finite
+        amount of time.
         """
         counter = 0
         timer_task = asyncio.create_task(asyncio.sleep(self.config.total_time))

--- a/tests/maintel/tma/test_random_walk.py
+++ b/tests/maintel/tma/test_random_walk.py
@@ -121,13 +121,13 @@ class TestRandomWalk(
             )
 
             sky_offsets = []
-            async for i, az, el, off in self.script.random_walk_azel_by_time():
-                sky_offsets.append(off)
+            async for data in self.script.random_walk_azel_by_time():
+                sky_offsets.append(data.offset)
 
                 # TODO: This should not be necessary
                 # However, if I remove it the loop keeps running forever
                 # It does not seem to happen when running the loop w/ hardware
-                if i == 50:
+                if data.counter == 50:
                     break
 
             assert np.isclose(np.mean(sky_offsets), 3.5, atol=0.01)

--- a/tests/maintel/tma/test_random_walk.py
+++ b/tests/maintel/tma/test_random_walk.py
@@ -20,11 +20,11 @@
 
 import asyncio
 import logging
-import unittest
 import types
-import pytest
+import unittest
 
 import numpy as np
+import pytest
 from lsst.ts import externalscripts, standardscripts
 from lsst.ts.externalscripts.maintel.tma import RandomWalk
 from lsst.ts.idl.enums import Script


### PR DESCRIPTION
The ``random_walk_azel_by_time`` function returns four values, but the ``for`` loop expected only three values.