### PR TITLE
DM-41536: Refactor LOVE stress and uptime tests for configuring URLs instead of domains

### DIFF
--- a/doc/news/DM-41536.misc.rst
+++ b/doc/news/DM-41536.misc.rst
@@ -1,0 +1,3 @@
+* In ``love_manager_client``, ``make_love_stress_tests`` and ``make_love_uptime_tests`` change location attribute to be an URL instead of a domain
+* In ``love_manager_client`` remove ``command_url``
+* In ``make_love_stress_tests`` and ``make_love_uptime_tests`` make both ``USER_USERNAME`` and ``USER_USER_PASS`` environment variables required

--- a/python/lsst/ts/externalscripts/make_love_uptime_tests.py
+++ b/python/lsst/ts/externalscripts/make_love_uptime_tests.py
@@ -105,9 +105,9 @@ class UptimeLOVE(salobj.BaseScript):
             description: Configuration for StressLOVE
             type: object
             properties:
-              host:
-                description: Host address of the running LOVE instance (web server) to monitor
-                    e.g. love.tu.lsst.org.
+              location:
+                description: Complete URL of the running LOVE instance (web server) to stress
+                    e.g. https://base-lsp.lsst.codes/love or http://love01.ls.lsst.org
                 type: string
               cscs:
                 description: List of CSC_name[:index]
@@ -122,7 +122,7 @@ class UptimeLOVE(salobj.BaseScript):
                     It is also approximate, because it is only checked every few seconds.
                 type: number
                 exclusiveMinimum: 0
-            required: [host, cscs, max_duration]
+            required: [location, cscs, max_duration]
             additionalProperties: false
         """
         return yaml.safe_load(schema_yaml)
@@ -141,9 +141,15 @@ class UptimeLOVE(salobj.BaseScript):
     async def configure(self, config):
         """Configure the script.
 
-        Specify the Uptime test configurations:
+        Look for credentials configured with environment variables:
+        - USER_USERNAME
+        - USER_USER_PASS
+        These should match the credentials used to log into the LOVE instance.
+
+        Also specify the Uptime test configurations:
         - LOVE host location
         - CSCs
+        - Maximum duration of the script execution
 
         Parameters
         ----------
@@ -154,12 +160,22 @@ class UptimeLOVE(salobj.BaseScript):
         -----
         Saves the results on several attributes:
 
+        * username  : `str`, LOVE username to use as authenticator
+        * password  : `str`, Password of the choosen LOVE user
         * config    : `types.SimpleNamespace`, same as config param
         * remotes   : a dict, with each item as
             CSC_name[:index]: `lsst.ts.salobj.Remote`
+        * max_duration : `float`, maximum duration of the
+            script execution (approximate)
 
         Constructing a `salobj.Remote` is slow (DM-17904), so configuration
         may take a 10s or 100s of seconds per CSC.
+
+        Raises
+        ------
+        RuntimeError
+            If environment variables USER_USERNAME or
+            USER_USER_PASS are not defined.
         """
         self.log.info("Configure started")
 
@@ -169,6 +185,10 @@ class UptimeLOVE(salobj.BaseScript):
         # get credentials
         self.username = os.environ.get("USER_USERNAME")
         self.password = os.environ.get("USER_USER_PASS")
+        if self.username is None:
+            raise RuntimeError(
+                "Configuration failed: environment variable USER_USERNAME not defined"
+            )
         if self.password is None:
             raise RuntimeError(
                 "Configuration failed: environment variable USER_USER_PASS not defined"
@@ -221,7 +241,7 @@ class UptimeLOVE(salobj.BaseScript):
         # Create clients and listen to ws messages
         self.log.info("Waiting for the Manager Client to be ready")
         self.client = LoveManagerClient(
-            self.config.host,
+            self.config.location,
             self.username,
             self.password,
             event_streams,
@@ -258,4 +278,5 @@ class UptimeLOVE(salobj.BaseScript):
     async def cleanup(self):
         """Return the system to its default status."""
         # Close the ManagerClient
-        await self.client.close()
+        if self.client is not None:
+            await self.client.close()

--- a/tests/test_make_love_stress_tests.py
+++ b/tests/test_make_love_stress_tests.py
@@ -42,11 +42,12 @@ class TestStressLOVE(
         return (self.script,)
 
     async def test_configure(self):
+        os.environ["USER_USERNAME"] = "TEST"
         os.environ["USER_USER_PASS"] = "TEST"
         async with self.make_script():
             # Try configure with minimum set of parameters declared
             # Note that all are scalars and should be converted to arrays
-            location = "love.tu.lsst.org"
+            location = "http://love.tu.lsst.org"
             number_of_clients = 50
             number_of_messages = 5000
             data = [

--- a/tests/test_make_love_uptime_tests.py
+++ b/tests/test_make_love_uptime_tests.py
@@ -47,7 +47,7 @@ class TestUptimeLOVE(
         async with self.make_script():
             # Try configure with minimum set of parameters declared
             # Note that all are scalars and should be converted to arrays
-            host = "love.tu.lsst.org"
+            location = "http://love.tu.lsst.org"
             cscs = [
                 "ATAOS",
                 "MTAirCompressor:1",
@@ -56,12 +56,12 @@ class TestUptimeLOVE(
             max_duration = 10
 
             await self.configure_script(
-                host=host,
+                location=location,
                 cscs=cscs,
                 max_duration=max_duration,
             )
 
-            assert self.script.config.host == host
+            assert self.script.config.location == location
             assert self.script.config.cscs == cscs
             assert self.script.config.max_duration == max_duration
 


### PR DESCRIPTION
PR to make tests more flexible so they can be used also for k8s deployments for instance. Also some docstrings were standardized and `make_love_stress_tests.py` was refactored to import the LOVEManagerClient class instead of defining it.