### PR TITLE
DM-41684: Implement the group_id subgrouping feature for intra/extra pair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pytest_session.txt
 # setuptools
 .eggs
 *.egg-info
+.clang-format
+.ruff.toml
+towncrier.toml

--- a/doc/news/DM-41684.feature.rst
+++ b/doc/news/DM-41684.feature.rst
@@ -1,0 +1,2 @@
+In ``auxtel/latiss_base_align.py`` added `self.next_supplemented_group_id()` call so that intra and extra focal images have the same group id.
+(`DM-41684 <https://jira.lsstcorp.org/browse/DM-41684>`_)

--- a/python/lsst/ts/externalscripts/auxtel/calsys_take_narrowband_data.py
+++ b/python/lsst/ts/externalscripts/auxtel/calsys_take_narrowband_data.py
@@ -424,14 +424,14 @@ class CalSysTakeNarrowbandData(salobj.BaseScript):
                 for fieldname in fieldnames:
                     row_dict[fieldname] = None
                 row_dict["Exposure Time"] = self.integration_times[i]
-                row_dict[
-                    "Fiber Spectrograph Exposure Time"
-                ] = self.fiber_spectrograph_integration_times[i]
+                row_dict["Fiber Spectrograph Exposure Time"] = (
+                    self.fiber_spectrograph_integration_times[i]
+                )
                 row_dict["Monochromator Grating"] = self.mono_grating_types[i]
                 row_dict["Monochromator Wavelength"] = self.wavelengths[i]
-                row_dict[
-                    "Monochromator Entrance Slit Size"
-                ] = self.mono_entrance_slit_widths[i]
+                row_dict["Monochromator Entrance Slit Size"] = (
+                    self.mono_entrance_slit_widths[i]
+                )
                 row_dict["Monochromator Exit Slit Size"] = self.mono_exit_slit_widths[i]
                 row_dict["Fiber Spectrograph Fits File"] = fiber_spectrograph_lfo_url
                 row_dict["Electrometer Fits File"] = electrometer_lfo_url
@@ -441,9 +441,9 @@ class CalSysTakeNarrowbandData(salobj.BaseScript):
                 if self.setup_spectrograph:
                     row_dict["ATSpectrograph Filter"] = self.latiss_filter[i]
                     row_dict["ATSpectrograph Grating"] = self.latiss_grating[i]
-                    row_dict[
-                        "ATSpectrograph Linear Stage Position"
-                    ] = self.latiss_stage_pos[i]
+                    row_dict["ATSpectrograph Linear Stage Position"] = (
+                        self.latiss_stage_pos[i]
+                    )
                 data_writer.writerow(row_dict)
         with open(f"{path}/{csv_filename}", newline="") as csvfile:
             data_reader = csv.DictReader(csvfile)

--- a/python/lsst/ts/externalscripts/auxtel/latiss_base_align.py
+++ b/python/lsst/ts/externalscripts/auxtel/latiss_base_align.py
@@ -242,10 +242,12 @@ class LatissBaseAlign(salobj.BaseScript, metaclass=abc.ABCMeta):
 
         self.log.debug("Taking intra-focal image")
 
+        supplemented_group_id = self.next_supplemented_group_id()
+
         intra_image = await self.latiss.take_cwfs(
             exptime=self.exposure_time,
             n=1,
-            group_id=self.group_id,
+            group_id=supplemented_group_id,
             filter=self.filter,
             grating=self.grating,
             reason="INTRA" + ("" if self.reason is None else f"_{self.reason}"),
@@ -269,7 +271,7 @@ class LatissBaseAlign(salobj.BaseScript, metaclass=abc.ABCMeta):
         extra_image = await self.latiss.take_cwfs(
             exptime=self.exposure_time,
             n=1,
-            group_id=self.group_id,
+            group_id=supplemented_group_id,
             filter=self.filter,
             grating=self.grating,
             reason="EXTRA" + ("" if self.reason is None else f"_{self.reason}"),

--- a/python/lsst/ts/externalscripts/maintel/track_target_sched.py
+++ b/python/lsst/ts/externalscripts/maintel/track_target_sched.py
@@ -48,9 +48,9 @@ class TrackTargetSched(TrackTarget):
         # Get the base schema from BaseTrackTargetAndTakeImage so this script
         # is compatible with the scheduler
         schema_dict = BaseTrackTargetAndTakeImage.get_base_schema()
-        schema_dict[
-            "$id"
-        ] = "https://github.com/lsst-ts/ts_externalscripts/maintel/track_target_sched.py"
+        schema_dict["$id"] = (
+            "https://github.com/lsst-ts/ts_externalscripts/maintel/track_target_sched.py"
+        )
         schema_dict["title"] = "TrackTargetSched v1"
         schema_dict["description"] = "Configuration for TrackTargetSched."
 


### PR DESCRIPTION
A supplemental group id is created before images are taken and this is used for both the intra and extra focal image