### PR TITLE
DM-44873: Ensure pipeline names/subsets/paths are correct in `ts_externalscripts`

### DIFF
--- a/doc/news/DM-44873.bugfix.rst
+++ b/doc/news/DM-44873.bugfix.rst
@@ -1,0 +1,2 @@
+Update pipeline paths, filenames, and subset names to reflect upstream changes in `cp_pipe` and `cp_verify`.
+

--- a/python/lsst/ts/externalscripts/auxtel/make_latiss_calibrations.py
+++ b/python/lsst/ts/externalscripts/auxtel/make_latiss_calibrations.py
@@ -74,7 +74,7 @@ class MakeLatissCalibrations(BaseMakeCalibrations):
     @property
     def pipeline_instrument(self):
         """String with instrument name for pipeline yaml file"""
-        return "Latiss"
+        return "LATISS"
 
     @property
     def detectors(self):

--- a/python/lsst/ts/externalscripts/base_make_calibrations.py
+++ b/python/lsst/ts/externalscripts/base_make_calibrations.py
@@ -324,7 +324,7 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
             do_gain_from_flat_pairs:
                 type: boolean
                 descriptor: Should the gain be estimated from each pair of flats
-                    taken at the same exposure time? Runs the cpPtc.yaml# generateGainFromFlatPairs \
+                    taken at the same exposure time? Runs the cpPtc.yaml#cpPtcGainFromFlatPairs \
                     pipeline. Use the 'config_options_ptc' parameter to pass options to the ISR and \
                     cpExtract tasks. This configuration will only be in effect if \
                     script_mode = BIAS_DARK_FLAT.
@@ -651,7 +651,7 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
             input_collections_defects = f"{self.config.input_collections_defects}"
 
         return (
-            "findDefects.yaml",
+            "cpDefects.yaml",
             (
                 f"-j {self.config.n_processes} -i {input_collections_defects} "
                 "--register-dataset-types "
@@ -665,7 +665,7 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
 
         Returns
         -------
-        cpPtc.yaml or cpPtc.yaml#gainFromFlatPairs : `str`
+        cpPtc.yaml or cpPtc.yaml#cpPtcGainFromFlatPairs : `str`
             cp_pipe PTC or gain from pairs pipeline.
 
         config_string : `str`
@@ -685,7 +685,7 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
         if (self.config.do_ptc is False) and (
             self.config.do_gain_from_flat_pairs is True
         ):
-            pipeline_yaml_file = "cpPtc.yaml#gainFromFlatPairs"
+            pipeline_yaml_file = "cpPtc.yaml#cpPtcGainFromFlatPairs"
         else:
             pipeline_yaml_file = "cpPtc.yaml"
 
@@ -806,7 +806,7 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
             List of bias exposure IDs.
         """
 
-        pipe_yaml = "VerifyBias.yaml"
+        pipe_yaml = "verifyBias.yaml"
         # If the combined calibration was not generated with the images
         # taken at the beginning of the script, the verification
         # pipetask will use the calibrations provided as input
@@ -850,7 +850,7 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
         exposure_ids_dark : `list`[`int`]
             List of dark exposure IDs.
         """
-        pipe_yaml = "VerifyDark.yaml"
+        pipe_yaml = "verifyDark.yaml"
         # If the combined calibration was not generated with the images
         # taken at the beginning of the script, the verification
         # pipetask will use the calibrations provided as input
@@ -895,7 +895,7 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
             List of flat exposure IDs.
         """
 
-        pipe_yaml = "VerifyFlat.yaml"
+        pipe_yaml = "verifyFlat.yaml"
         # If the combined calibration was not generated with the images
         # taken at the beginning of the script, the verification
         # pipetask will use the calibrations provided as input

--- a/python/lsst/ts/externalscripts/maintel/make_comcam_calibrations.py
+++ b/python/lsst/ts/externalscripts/maintel/make_comcam_calibrations.py
@@ -74,7 +74,7 @@ class MakeComCamCalibrations(BaseMakeCalibrations):
     @property
     def pipeline_instrument(self):
         """String with instrument name for pipeline yaml file"""
-        return "LsstComCam"
+        return "LSSTComCam"
 
     @property
     def detectors(self):


### PR DESCRIPTION
Update calibration code for cp_pipe/cp_verify changes due to RFC-1013.

- Switch instrument names in file path to match default:
  - Latiss -> LATISS
  - LsstComCam -> LSSTComCam
- Fix changes in pipeline definition names:
  - findDefects.yaml -> cpDefects.yaml
  - VerifyBias.yaml -> verifyBias.yaml (similar changes for verifyDark.yaml and verifyFlat.yaml).
- Fix subset name change:
  - gainFromFlatPairs -> cpPtcGainFromFlatPairs