### PR TITLE
tickets/DM-41364: Fix doc page

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,10 +2,10 @@
 This configuration only affects single-package Sphinx documentation builds.
 """
 
-import lsst.ts.standardscripts  # noqa
+import lsst.ts.externalscripts  # noqa
 from documenteer.conf.pipelinespkg import *  # type: ignore # noqa
 
-project = "ts_standardscripts"
+project = "ts_externalscripts"
 html_theme_options["logotext"] = project  # type: ignore # noqa
 html_title = project
 html_short_title = project

--- a/doc/news/DM-41364.doc.rst
+++ b/doc/news/DM-41364.doc.rst
@@ -1,0 +1,1 @@
+Fix ``ts_externalscripts`` doc page to correctly show ``ts_externalscripts`` instead of ``ts_standardscripts``.


### PR DESCRIPTION
Fixing doc page that was showing ``ts_standardscripts`` instead of ``ts_externalscripts``.