### PR TITLE
Implement tcs_ready_to_take_data integration for on-sky images

### DIFF
--- a/doc/news/DM-46179.feature.rst
+++ b/doc/news/DM-46179.feature.rst
@@ -1,0 +1,8 @@
+Extend TCS readiness check to other image types beyond OBJECT, such as:
+ENGTEST, CWFS and ACQ.
+
+Configure TCS synchronization to the following script:
+
+- auxtel/build_pointing_model.py
+- auxtel/correct_pointing.py
+- auxtel/latiss_acquire.py

--- a/python/lsst/ts/externalscripts/auxtel/build_pointing_model.py
+++ b/python/lsst/ts/externalscripts/auxtel/build_pointing_model.py
@@ -78,7 +78,11 @@ class BuildPointingModel(BaseScript):
 
         if remotes:
             self.atcs = ATCS(domain=self.domain, log=self.log)
-            self.latiss = LATISS(domain=self.domain, log=self.log)
+            self.latiss = LATISS(
+                domain=self.domain,
+                log=self.log,
+                tcs_ready_to_take_data=self.atcs.ready_to_take_data,
+            )
         else:
             self.atcs = ATCS(
                 domain=self.domain, log=self.log, intended_usage=ATCSUsages.DryTest

--- a/python/lsst/ts/externalscripts/auxtel/correct_pointing.py
+++ b/python/lsst/ts/externalscripts/auxtel/correct_pointing.py
@@ -62,7 +62,11 @@ class CorrectPointing(BaseScript):
 
         if remotes:
             self.atcs = ATCS(domain=self.domain, log=self.log)
-            self.latiss = LATISS(domain=self.domain, log=self.log)
+            self.latiss = LATISS(
+                domain=self.domain,
+                log=self.log,
+                tcs_ready_to_take_data=self.atcs.ready_to_take_data,
+            )
         else:
             self.atcs = ATCS(
                 domain=self.domain, log=self.log, intended_usage=ATCSUsages.DryTest

--- a/python/lsst/ts/externalscripts/auxtel/latiss_acquire.py
+++ b/python/lsst/ts/externalscripts/auxtel/latiss_acquire.py
@@ -78,10 +78,16 @@ class LatissAcquire(salobj.BaseScript):
 
         atcs_usage = None if add_remotes else ATCSUsages.DryTest
 
-        self.latiss = LATISS(
-            domain=self.domain, intended_usage=latiss_usage, log=self.log
-        )
         self.atcs = ATCS(domain=self.domain, intended_usage=atcs_usage, log=self.log)
+
+        tcs_ready_to_take_data = self.atcs.ready_to_take_data if add_remotes else None
+
+        self.latiss = LATISS(
+            domain=self.domain,
+            intended_usage=latiss_usage,
+            log=self.log,
+            tcs_ready_to_take_data=tcs_ready_to_take_data,
+        )
 
         self.image_in_oods_timeout = 15.0
 


### PR DESCRIPTION
Integrated the `tcs_ready_to_take_data` method across scripts responsible for taking on-sky images, specifically for image types: OBJECT, ENTEST, ACQ, CWFS

Before I keep going I want to make sure I'm not deviating from the intended development objectives. Please see unit test in standardscripts draft PR [#229](https://github.com/lsst-ts/ts_standardscripts/pull/229)