### PR TITLE
Point to sasquatch enabled Butler repo for LATISS and ComCam.

### DIFF
--- a/doc/news/DM-46754.feature.rst
+++ b/doc/news/DM-46754.feature.rst
@@ -1,0 +1,1 @@
+Point calibration scripts to Sasquatch-enabled Butler repo for LATISS and LSSTComCam.

--- a/python/lsst/ts/externalscripts/auxtel/make_latiss_calibrations.py
+++ b/python/lsst/ts/externalscripts/auxtel/make_latiss_calibrations.py
@@ -164,7 +164,7 @@ class MakeLatissCalibrations(BaseMakeCalibrations):
             repo:
                 type: string
                 descriptor: Butler repository.
-                default: "/repo/LATISS"
+                default: "/repo/LATISS/butler+sasquatch.yaml"
         additionalProperties: false
         """
         schema_dict = yaml.safe_load(schema)

--- a/python/lsst/ts/externalscripts/maintel/make_comcam_calibrations.py
+++ b/python/lsst/ts/externalscripts/maintel/make_comcam_calibrations.py
@@ -172,7 +172,7 @@ class MakeComCamCalibrations(BaseMakeCalibrations):
             repo:
                 type: string
                 descriptor: Butler repository.
-                default: "/repo/LSSTComCam"
+                default: "/repo/LSSTComCam/butler+sasquatch.yaml"
         additionalProperties: false
         """
         schema_dict = yaml.safe_load(schema)


### PR DESCRIPTION
This simple update will deploy sasquatch at the summit. 
@tribeiro could you run tests with these modifications to make sure it won't break anything?    