### PR TITLE
DM-48380: Identify why summit OCPS is having issues with LATISS calibration checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ config.log
 *.log
 .vscode
 version.py
+python/*.dist-info/
 
 # Pytest
 tests/.tests

--- a/doc/news/DM-48380.bugfix.1.rst
+++ b/doc/news/DM-48380.bugfix.1.rst
@@ -1,0 +1,1 @@
+BaseMakeCalibrations.call_pipetask would fail to find pipeline if a subset was supplied.

--- a/doc/news/DM-48380.bugfix.2.rst
+++ b/doc/news/DM-48380.bugfix.2.rst
@@ -1,0 +1,1 @@
+BaseMakeCalibrations.call_pipetask did not have the updated location for default pipelines.

--- a/doc/news/DM-48380.bugfix.3.rst
+++ b/doc/news/DM-48380.bugfix.3.rst
@@ -1,0 +1,1 @@
+BaseMakeCalibrations.call_pipetask and BaseMakeCalibrations.verify_calib use a string representation of a tuple for the exposure_ids.  This adds a trailing comma if the tuple has only one element, causing a syntax error.

--- a/python/lsst/ts/externalscripts/base_make_calibrations.py
+++ b/python/lsst/ts/externalscripts/base_make_calibrations.py
@@ -757,8 +757,15 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
         # Use the camera-agnostic yaml file if the camera-specific
         # file does not exist.
         cp_pipe_dir = getPackageDir("cp_pipe")
+
+        on_disk_yaml = pipe_yaml
+        if "#" in on_disk_yaml:
+            # We are using a subset from this yaml, and so must remove
+            # the subset before checking for file existence.
+            on_disk_yaml = on_disk_yaml.split("#", 1)[0]
+
         pipeline_yaml_file = os.path.join(
-            cp_pipe_dir, "pipelines", self.pipeline_instrument, pipe_yaml
+            cp_pipe_dir, "pipelines", self.pipeline_instrument, on_disk_yaml
         )
         file_exists = os.path.exists(pipeline_yaml_file)
         if file_exists:

--- a/python/lsst/ts/externalscripts/base_make_calibrations.py
+++ b/python/lsst/ts/externalscripts/base_make_calibrations.py
@@ -773,7 +773,7 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
                 f"${{CP_PIPE_DIR}}/pipelines/{self.pipeline_instrument}/{pipe_yaml}"
             )
         else:
-            pipeline_yaml_file = f"${{CP_PIPE_DIR}}/pipelines/{pipe_yaml}"
+            pipeline_yaml_file = f"${{CP_PIPE_DIR}}/pipelines/_ingredients/{pipe_yaml}"
 
         # This returns the in-progress acknowledgement with the job identifier
         ack = await self.ocps.cmd_execute.set_start(

--- a/python/lsst/ts/externalscripts/base_make_calibrations.py
+++ b/python/lsst/ts/externalscripts/base_make_calibrations.py
@@ -776,7 +776,9 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
             pipeline_yaml_file = f"${{CP_PIPE_DIR}}/pipelines/_ingredients/{pipe_yaml}"
 
         # This returns the in-progress acknowledgement with the job identifier
-        exposure_id_string = str(exposure_ids) if len(exposure_ids) > 1 else f"({exposure_ids[0]})"
+        exposure_id_string = (
+            str(exposure_ids) if len(exposure_ids) > 1 else f"({exposure_ids[0]})"
+        )
         ack = await self.ocps.cmd_execute.set_start(
             wait_done=False,
             pipeline=f"{pipeline_yaml_file}",
@@ -998,7 +1000,9 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
             pipeline_yaml_file = f"${{CP_VERIFY_DIR}}/pipelines/{pipe_yaml}"
 
         # Verify the combined calibration
-        exposure_id_string = str(exposure_ids) if len(exposure_ids) > 1 else f"({exposure_ids[0]})"
+        exposure_id_string = (
+            str(exposure_ids) if len(exposure_ids) > 1 else f"({exposure_ids[0]})"
+        )
         ack = await self.ocps.cmd_execute.set_start(
             wait_done=False,
             pipeline=f"{pipeline_yaml_file}",

--- a/python/lsst/ts/externalscripts/base_make_calibrations.py
+++ b/python/lsst/ts/externalscripts/base_make_calibrations.py
@@ -776,13 +776,14 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
             pipeline_yaml_file = f"${{CP_PIPE_DIR}}/pipelines/_ingredients/{pipe_yaml}"
 
         # This returns the in-progress acknowledgement with the job identifier
+        exposure_id_string = str(exposure_ids) if len(exposure_ids) > 1 else f"({exposure_ids[0]})"
         ack = await self.ocps.cmd_execute.set_start(
             wait_done=False,
             pipeline=f"{pipeline_yaml_file}",
             version="",
             config=f"{config_string}",
             data_query=f"instrument='{self.instrument_name}' AND"
-            f" detector IN {self.detectors_string} AND exposure IN {exposure_ids}",
+            f" detector IN {self.detectors_string} AND exposure IN {exposure_id_string}",
         )
         self.log.debug(
             f"Received acknowledgement of ocps command for {image_type} pipetask."
@@ -997,13 +998,14 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
             pipeline_yaml_file = f"${{CP_VERIFY_DIR}}/pipelines/{pipe_yaml}"
 
         # Verify the combined calibration
+        exposure_id_string = str(exposure_ids) if len(exposure_ids) > 1 else f"({exposure_ids[0]})"
         ack = await self.ocps.cmd_execute.set_start(
             wait_done=False,
             pipeline=f"{pipeline_yaml_file}",
             version="",
             config=f"{config_string}",
             data_query=f"instrument='{self.instrument_name}' AND"
-            f" detector IN {self.detectors_string} AND exposure IN {exposure_ids}",
+            f" detector IN {self.detectors_string} AND exposure IN {exposure_id_string}",
         )
         self.log.debug(
             f"Received acknowledgement of ocps command for {image_type} verification."


### PR DESCRIPTION
Fix bugs:
* Pipeline search would fail if a subset was supplied.
* Default pipeline location changed, but wasn't updated.
* A tuple converts to a valid argument to the IN operator unless it has only a single element, in which it has a trailing comma that is not allowed.

