### PR TITLE
DM-49346: Park Calibration Projector

### DIFF
--- a/doc/news/DM-49346.feature.rst
+++ b/doc/news/DM-49346.feature.rst
@@ -1,0 +1,1 @@
+Included a script that parks the calibration projector in a safe place and turns off the LEDs

--- a/python/lsst/ts/externalscripts/data/scripts/maintel/park_calibration_projector.py
+++ b/python/lsst/ts/externalscripts/data/scripts/maintel/park_calibration_projector.py
@@ -1,6 +1,7 @@
-# This file is part of ts_externalcripts.
+#!/usr/bin/env python
+# This file is part of ts_externalscripts
 #
-# Developed for the Rubin Observatory Telescope and Site System.
+# Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project
 # (https://www.lsst.org).
 # See the COPYRIGHT file at the top-level directory of this distribution
@@ -17,19 +18,9 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .make_comcam_calibrations import *
-from .make_lsstcam_calibrations import *
-from .parameter_march_comcam import *
-from .parameter_march_lsstcam import *
-from .park_calibration_projector import *
-from .setup_whitelight_flats import *
-from .take_comcam_guider_image import *
-from .take_ptc_flats_comcam import *
-from .take_rotated_comcam import *
-from .take_rotated_lsstcam import *
-from .take_twilight_flats_comcam import *
-from .take_twilight_flats_lsstcam import *
-from .track_target_sched import *
-from .warmup_hexapod import *
+import asyncio
+
+from lsst.ts.externalscripts.maintel import ParkCalibrationProjector
+
+asyncio.run(ParkCalibrationProjector.amain())

--- a/python/lsst/ts/externalscripts/maintel/park_calibration_projector.py
+++ b/python/lsst/ts/externalscripts/maintel/park_calibration_projector.py
@@ -1,0 +1,107 @@
+# This file is part of ts_externalscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["ParkCalibrationProjector"]
+
+import yaml
+from lsst.ts import salobj
+from lsst.ts.observatory.control.maintel.mtcalsys import MTCalsys
+
+
+class ParkCalibrationProjector(salobj.BaseScript):
+    """Move the calibration projector into a safe position
+
+    Parameters
+    ----------
+    index : int
+        Index of Script SAL component.
+    """
+
+    def __init__(self, index):
+        super().__init__(
+            index=index,
+            descr="Park Calibration Projector",
+        )
+
+        self.mtcalsys = None
+
+    def set_metadata(self, metadata):
+        metadata.duration = 30
+
+    @classmethod
+    def get_schema(cls):
+        schema_yaml = """
+            $schema: http://json-schema.org/draft-07/schema#
+            $id: https://github.com/lsst-ts/ts_externalscripts/maintel/calibrations/park_calibration_projector.yaml # noqa: E501
+            title: ParkCalibrationProjector v1
+            description: Park the Calibration after use to ensure LEDs are off and stages
+                are in a safe plce
+            type: object
+            properties:
+                ignore:
+                    description: >-
+                        CSCs from teh group to ignore in status check
+                    type: array
+                    items:
+                        type: string
+
+            additionalProperties: false
+        """
+        return yaml.safe_load(schema_yaml)
+
+    async def configure(self, config):
+        """Configure the script.
+
+        Parameters
+        ----------
+        config : ``self.cmd_configure.DataType``
+
+        """
+        self.log.info("Configure started")
+        if self.mtcalsys is None:
+            self.log.debug("Creating MTCalSys.")
+            self.mtcalsys = MTCalsys(domain=self.domain, log=self.log)
+            await self.mtcalsys.start_task
+
+        if hasattr(config, "ignore"):
+            self.mtcalsys.disable_checks_for_components(components=config.ignore)
+
+        self.log.info("Configure completed")
+
+    async def run(self):
+        """Run script."""
+        await self.mtcalsys.assert_all_enabled()
+
+        self.log.info("Parking Calibration Projector")
+        await self.mtcalsys.park_projector()
+
+        params = await self.mtcalsys.get_projector_setup()
+
+        self.log.info(
+            f"Projector Location is {params[0]}, \n"
+            f"LED Location stage pos @: {params[1]}, \n"
+            f"LED Focus stage pos @: {params[2]}, \n"
+            f"Laser Focus stage pos @: {params[3]}, \n"
+            f"LED State stage pos @: {params[4]}"
+        )
+
+        led_location = params[1]
+        assert led_location == self.mtcalsys.led_rest_position

--- a/tests/maintel/test_park_calibration_projector.py
+++ b/tests/maintel/test_park_calibration_projector.py
@@ -1,0 +1,126 @@
+# This file is part of ts_externalscripts
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import os
+import unittest
+
+import pytest
+from lsst.ts import externalscripts, standardscripts, utils
+from lsst.ts.externalscripts.maintel.park_calibration_projector import (
+    ParkCalibrationProjector,
+)
+from lsst.ts.observatory.control.maintel.mtcalsys import MTCalsys
+from lsst.ts.xml.enums import Script
+
+index_gen = utils.index_generator()
+
+
+class TestParkCalibrationProjector(
+    standardscripts.BaseScriptTestCase, unittest.IsolatedAsyncioTestCase
+):
+    def setUp(self):
+        self.log = logging.getLogger(__name__)
+        self.log.propagate = True
+        self.projector_setup = ("test_led", 100.0, 10.0, 10.0, "On")
+
+    @property
+    def remote_group(self) -> MTCalsys:
+        """The remote_group property."""
+        return self.mtcalsys
+
+    async def basic_make_script(self, index):
+        self.log.debug("Starting basic_make script")
+        self.script = ParkCalibrationProjector(index=index)
+
+        await self.mock_mtcalsys()
+
+        self.log.debug("Finished initializing from basic_make_script")
+        return (self.script,)
+
+    async def mock_mtcalsys(self):
+        """Mock Calsys CSCs"""
+        self.script.mtcalsys = unittest.mock.AsyncMock()
+        self.script.mtcalsys.assert_all_enabled = unittest.mock.AsyncMock()
+        self.script.mtcalsys.get_projector_setup = unittest.mock.AsyncMock(
+            return_value=self.projector_setup
+        )
+        self.script.mtcalsys.led_rest_position = 100.0
+
+    async def test_configure(self):
+        config = {
+            "ignore": [
+                "TunableLaser",
+                "FiberSpectrograph:101",
+                "FiberSpectrograph:102",
+                "Electrometer:103",
+            ]
+        }
+        async with self.make_script():
+            await self.configure_script(**config)
+            assert self.script.state.state == Script.ScriptState.CONFIGURED
+
+    async def test_run_without_failures(self):
+        config = {
+            "ignore": [
+                "TunableLaser",
+                "FiberSpectrograph:101",
+                "FiberSpectrograph:102",
+                "Electrometer:103",
+            ]
+        }
+        async with self.make_script():
+            await self.configure_script(**config)
+            assert self.script.state.state == Script.ScriptState.CONFIGURED
+
+            # Run the script
+            self.log.debug("Running the script")
+            await self.run_script()
+            assert self.script.state.state == Script.ScriptState.DONE
+
+    async def test_park_failure(self):
+        config = {
+            "ignore": [
+                "TunableLaser",
+                "FiberSpectrograph:101",
+                "FiberSpectrograph:102",
+                "Electrometer:103",
+            ]
+        }
+        self.projector_setup = ("test_fail", 0.0, 0.0, 0.0, "off")
+        async with self.make_script():
+            await self.configure_script(**config)
+            assert self.script.state.state == Script.ScriptState.CONFIGURED
+
+            # Run the script
+            self.log.debug("Running the script")
+            with pytest.raises(AssertionError):
+                await self.run_script()
+
+    async def test_executable(self):
+        scripts_dir = externalscripts.get_scripts_dir()
+        script_path = os.path.join(
+            scripts_dir, "maintel", "park_calibration_projector.py"
+        )
+        await self.check_executable(script_path)
+
+    if __name__ == "__main__":
+        unittest.main()


### PR DESCRIPTION
After using the Calibration projector, for either the white light or monochromatic flats, the projector should be moved so that it is in a safe place and all LEDs turned off. This script accomplishes that.