### PR TITLE
DM-49663: Further bitrot in summit calibration checkouts

### DIFF
--- a/doc/news/DM-49663.bugfix.rst
+++ b/doc/news/DM-49663.bugfix.rst
@@ -1,0 +1,2 @@
+Switch LATISS repo in `make_latiss_calibrations.py` to point to sasquatch backed version.
+Demote log message from info to debug, as it contains no day-to-day useful information.

--- a/python/lsst/ts/externalscripts/auxtel/make_latiss_calibrations.py
+++ b/python/lsst/ts/externalscripts/auxtel/make_latiss_calibrations.py
@@ -162,7 +162,7 @@ class MakeLatissCalibrations(BaseMakeCalibrations):
             repo:
                 type: string
                 descriptor: Butler repository.
-                default: "/repo/LATISS/butler+sasquatch.yaml"
+                default: "LATISS+sasquatch"
         additionalProperties: false
         """
         schema_dict = yaml.safe_load(schema)

--- a/python/lsst/ts/externalscripts/base_make_calibrations.py
+++ b/python/lsst/ts/externalscripts/base_make_calibrations.py
@@ -1667,7 +1667,7 @@ class BaseMakeCalibrations(BaseBlockScript, metaclass=abc.ABCMeta):
             response_ocps_calib_pipetask = await self.call_pipetask(im_type)
             job_id_calib = response_ocps_calib_pipetask["jobId"]
         else:
-            self.log.info(
+            self.log.debug(
                 f"A combined {im_type} will not be generated from the "
                 "images taken as part of this script. Any needed input "
                 "calibrations by the verification pipetasks will be "


### PR DESCRIPTION
Switch LATISS repo in `make_latiss_calibrations.py` to point to sasquatch backed version.

Demote log message from info to debug, as it contains no day-to-day useful information. 
Add news snippet.